### PR TITLE
Docker support for testing vim plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.5
+USER root
+WORKDIR /root
+ADD example.vimrc .vimrc
+RUN apk add --no-cache curl vim git terraform && \
+    curl -fLo ~/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim && \
+    vim +PlugInstall +qall
+ENTRYPOINT ["vim"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM alpine:3.5
+FROM base/archlinux
 USER root
 WORKDIR /root
 ADD example.vimrc .vimrc
-RUN apk add --no-cache curl vim git terraform && \
+RUN pacman -Syy && \
+    pacman -S vim ruby git unzip --noconfirm && \
     curl -fLo ~/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim && \
-    vim +PlugInstall +qall
+    vim +PlugInstall +qall && \
+    curl https://releases.hashicorp.com/terraform/0.9.4/terraform_0.9.4_linux_amd64.zip -o terraform_0.9.4_linux_amd64.zip && \
+    unzip terraform_0.9.4_linux_amd64.zip && \
+    mv terraform /usr/bin/terraform
 ENTRYPOINT ["vim"]

--- a/example.vimrc
+++ b/example.vimrc
@@ -1,0 +1,17 @@
+" Minimal Configuration
+set nocompatible
+syntax on
+filetype plugin indent on
+
+call plug#begin('~/.vim/plugged')
+Plug 'hashivim/vim-terraform'
+Plug 'vim-syntastic/syntastic'
+Plug 'juliosueiras/vim-terraform-completion'
+call plug#end()
+
+" (Optional)Remove Info(Preview) window
+set completeopt-=preview
+
+" (Optional)Hide Info(Preview) window after completions
+autocmd CursorMovedI * if pumvisible() == 0|pclose|endif
+autocmd InsertLeave * if pumvisible() == 0|pclose|endif

--- a/test-vim-terraform-completion
+++ b/test-vim-terraform-completion
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+readonly IMAGE="vim-terraform-completion"
+readonly TAG=latest
+readonly ARGS="$@"
+
+# Stop running if the user is root
+if [[ "$(id -u $(whoami))" -eq "0" ]]
+then
+    echo "cannot run as root!, exiting"
+    exit 1
+fi
+
+
+# If the specified image isn't present, build it
+if [[ -z $(docker images | grep -w "$IMAGE" | grep -w "$TAG") ]]
+then
+    docker build -t vim-terraform-completion:latest .
+fi
+
+# run container
+docker run --rm -it $IMAGE:$TAG test.tf
+


### PR DESCRIPTION
- adds Dockerfile describing test image on alpine with curl, vim, git,
  the minimal configuration plugins, and an example .vimrc file
- adds an example.vimrc which is injected into the test image
- adds a bash script for easily building and running the docker test