### PR TITLE
Fix ctags regex

### DIFF
--- a/ctags/terraform.ctags
+++ b/ctags/terraform.ctags
@@ -1,9 +1,9 @@
 --langdef=terraform
 --langmap=terraform:.tf.tfvars
---regex-terraform=/^\s*resource\s*"([^"]*)"\s*"([^"]*)"/\1.\2/r,Resource/
---regex-terraform=/^\s*data\s*"([^"]*)"\s*"([^"]*)"/\1.\2/d,Data/
---regex-terraform=/^\s*variable\s*"([^"]*)"/\1/v,Variable/
---regex-terraform=/^\s*provider\s*"([^"]*)"/\1/p,Provider/
---regex-terraform=/^\s*module\s*"([^"]*)"/\1/m,Module/
---regex-terraform=/^\s*output\s*"([^"]*)"/\1/o,Output/
---regex-terraform=/^([a-z0-9_]+)\s*=/\1/f,TFVar/
+--regex-terraform=/^[[:space:]]*resource[[:space:]]*"([^"]*)"[[:space:]]*"([^"]*)"/\1.\2/r,Resource/
+--regex-terraform=/^[[:space:]]*data[[:space:]]*"([^"]*)"[[:space:]]*"([^"]*)"/\1.\2/d,Data/
+--regex-terraform=/^[[:space:]]*variable[[:space:]]*"([^"]*)"/\1/v,Variable/
+--regex-terraform=/^[[:space:]]*provider[[:space:]]*"([^"]*)"/\1/p,Provider/
+--regex-terraform=/^[[:space:]]*module[[:space:]]*"([^"]*)"/\1/m,Module/
+--regex-terraform=/^[[:space:]]*output[[:space:]]*"([^"]*)"/\1/o,Output/
+--regex-terraform=/^([a-z0-9_]+)[[:space:]]*=/\1/f,TFVar/


### PR DESCRIPTION
# What?
Change the ctags regex from `\s` to `[[:space:]]`.

# Why?
When using exuberant ctags version 5.8 on macosx (from homebrew), `\s` doesn't find any tags but changing it to `[[:space:]]` does. Also tested against exuberant ctags 5.9 on Ubuntu Xenial 16.04 and it works to (fwiw, I use `[[:space:]]` in my personal ctags too for other things instead of `\s`).