### PR TITLE
Fix redraw problems when opening Terraform docs

### DIFF
--- a/autoload/terraformcomplete.vim
+++ b/autoload/terraformcomplete.vim
@@ -114,8 +114,10 @@ function! terraformcomplete#OpenDoc()
         "(Windows) cmd /c start filename_or_URL
         if system('uname -s') == 'Darwin'
             silent! execute ':!open ' . a:link
+            silent! execute ':redraw!'
         else
             silent! execute ':!xdg-open ' . a:link
+            silent! execute ':redraw!'
         endif
     catch
     endtry


### PR DESCRIPTION
When using the <leader>o shortcut to open documentation for Terraform
resources it was causing Vim to become corrupted and not redraw. I have
fixed this by having it notify Vim to redraw after the documentation has
been opened.