### PR TITLE
Remove the html extension when loading docs

### DIFF
--- a/autoload/terraformcomplete.vim
+++ b/autoload/terraformcomplete.vim
@@ -109,7 +109,7 @@ function! terraformcomplete#OpenDoc()
             let a_link .= '/d'
         endif
 
-        let a_link .= '/' . a_resource . '.html\#' . a_arg
+        let a_link .= '/' . a_resource . '\#' . a_arg
 
         "(Windows) cmd /c start filename_or_URL
         if system('uname -s') =~ 'Darwin'


### PR DESCRIPTION
The Terraform documentation no longer has .html on the end of the
documentation URLs. Removing the .html from the code as it was resulting
in the code taking you to a 404 page instead of the documentation for
the required resource.